### PR TITLE
Added drupal_install_profile variable to site install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ MySQL database username, password, and database name for Drupal to use.
 
 The public url of the git repository you want to clone. Use `drupal_core_version` to clone a particular branch. (*Note: Usually you shouldn't change this from the default, unless you need to use a private fork of Drupal.*).
 
+    drupal_install_profile: standard
+
+The install profile to use. If you're installing Drupal 6.x, you should update this from 'standard' to 'default'.
+
 ## Dependencies
 
   - geerlingguy.git

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,7 @@ drupal_mysql_database: drupal
 
 # The Drupal git url from which Drupal will be cloned.
 drupal_repo_url: "http://git.drupal.org/project/drupal.git"
+
+# The Drupal install profile to be used
+# See note in readme if installing the Drupal 6.x
+drupal_install_profile: standard

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -16,7 +16,7 @@
 
 - name: Install Drupal.
   command: >
-    drush si -y
+    drush si {{ drupal_install_profile }} -y
     --site-name="{{ drupal_site_name }}"
     --account-name=admin
     --account-pass=admin


### PR DESCRIPTION
I commonly use a custom install profile with Drupal projects. This variable would allow a user to specify which install profile to use during the drush site-install task. 
