### PR TITLE
Added drupal_admin_name and drupal_admin_password to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ The domain/DNS name of the drupal site. If using for local testing/development, 
 
 The site name (will be used as the home page title and anywhere else the site name is displayed).
 
+    drupal_admin_name: admin
+
+The username that gets assigned to the super admin (user 1).
+
+    drupal_admin_password: admin
+
+The password for the super admin.
+
     drupal_webserver_daemon: apache2
 
 The daemon name for the webserver you're running (could be `apache2`, `httpd`, `nginx`, etc.). Used to restart the appropriate service after Drupal is configured and installed.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,12 @@ drupal_domain: "drupaltest.dev"
 # Your Drupal site name.
 drupal_site_name: "Drupal Example"
 
+# Your Drupal super admin name
+drupal_admin_name: admin
+
+# Your Drupal super admin password
+drupal_admin_password: admin
+
 # The webserver you're running (e.g. 'apache2', 'httpd', 'nginx').
 drupal_webserver_daemon: apache2
 

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -18,8 +18,8 @@
   command: >
     drush si {{ drupal_install_profile }} -y
     --site-name="{{ drupal_site_name }}"
-    --account-name=admin
-    --account-pass=admin
+    --account-name={{ drupal_admin_name }}
+    --account-pass={{ drupal_admin_password}}
     --db-url=mysql://{{ drupal_mysql_user }}:{{ drupal_mysql_password }}@localhost/{{ drupal_mysql_database }}
     chdir={{ drupal_core_path }}
     creates={{ drupal_core_path }}/sites/default/settings.php


### PR DESCRIPTION
I think this is helpful for those who would rather not install the site initially with "admin" "admin" as the username and pw. Thanks for your consideration. 
