### PR TITLE
Added RedHat and Debian vars files, allowing for variable vhost directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Include OS-specific variables.
+  include_vars: "{{ ansible_os_family }}.yml"
+
 - include: general.yml
 - include: db.yml
 - include: web.yml

--- a/tasks/web.yml
+++ b/tasks/web.yml
@@ -3,7 +3,7 @@
 - name: Add Apache virtualhost for Drupal.
   template:
     src: drupal-vhost.conf.j2
-    dest: "/etc/apache2/sites-enabled/{{ drupal_domain }}.conf"
+    dest: "/{{ apache_sites_conf_path }}/{{ drupal_domain }}.conf"
     owner: root
     group: root
     mode: 0644

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,2 @@
+---
+apache_sites_conf_path: /etc/apache2/sites-enabled

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,2 @@
+---
+apache_sites_conf_path: /etc/httpd/conf.d


### PR DESCRIPTION
This PR fixing the Drupal playbook to allow it to work on RedHat and Debian systems by making the VHOST directory a variable.

It introduces a new variable: apache_sites_conf_path

RedHat:  /etc/httpd/conf.d
Debian: /etc/apache2/sites-enabled

I'm not sure if this is complete, or if the variable name should change, and haven't tested it on CentOS < 7, but I figured I'd submit a PR and get the ball rolling.

Thanks!