### PR TITLE
Add handler to clear opcache

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: clear opcache
+  command: "{{ drush_path }} eval \"if (function_exists('apc_clear_cache')) {apc_clear_cache();}if (function_exists('opcache_reset')) {opcache_reset();}\""
+  args:
+    chdir: "{{ drupal_core_path }}"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -17,7 +17,7 @@
     dest: "{{ drupal_deploy_dir }}"
     accept_hostkey: "{{ drupal_deploy_accept_hostkey }}"
   register: drupal_deploy_repo_updated
-  notify: restart webserver
+  notify: clear opcache
   become: no
 
 - name: Check if a composer.json file is present.

--- a/tasks/install-site.yml
+++ b/tasks/install-site.yml
@@ -29,7 +29,7 @@
     {{ drupal_site_install_extra_args | default([]) | join(" ") }}
   args:
     chdir: "{{ drupal_core_path }}"
-  notify: restart webserver
+  notify: clear opcache
   when: "'Successful' not in drupal_site_installed.stdout"
   become: no
 


### PR DESCRIPTION
This clears opcache via `drush eval` instead of restarting the webserver
or the php-fpm service.

My go at a solution for #35 