### PR TITLE
Support configurable Git SSH deploy key

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Available variables are listed below, along with default values (see `defaults/m
     drupal_deploy_update: true
     drupal_deploy_dir: "/var/www/drupal"
     drupal_deploy_accept_hostkey: no
+    drupal_deploy_key: none
 
 Set `drupal_deploy` to `true` and `drupal_build_composer*` to `false` if you would like to deploy Drupal to your server from an existing Git repository. The other options all apply to the Git checkout operation:
 
@@ -36,6 +37,7 @@ Set `drupal_deploy` to `true` and `drupal_build_composer*` to `false` if you wou
   - `update`: whether the repository should be updated to the latest commit, if `version` is a branch
   - `dir`: The directory into which the repository will be checked out
   - `accept_hostkey`: Whether to automatically accept the Git server's hostkey on the first connection.
+  - `drupal_ssh_deploy_key`: SSH key to use for Git repository, if any.  The specified key will be copied from the host machine to the `~/.ssh` directory of the target machine.  If this value is omitted, Git's default behavior will be used.
 
 ### Build a project from a Drush Make file
 

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,4 +1,13 @@
 ---
+- name: Copy deploy key to target.
+  copy:
+    backup: Yes
+    mode: 0400
+    src: "{{ drupal_ssh_deploy_key }}"
+    dest: "~/.ssh/{{ drupal_ssh_deploy_key | basename }}"
+  become: no
+  when: drupal_ssh_deploy_key is defined
+
 - name: Ensure drupal_deploy_dir directory exists.
   file:
     path: "{{ drupal_deploy_dir }}"
@@ -16,6 +25,7 @@
     force: yes
     dest: "{{ drupal_deploy_dir }}"
     accept_hostkey: "{{ drupal_deploy_accept_hostkey }}"
+    key_file: "{{ drupal_ssh_deploy_key is defined | ternary( '~/.ssh/' + (drupal_ssh_deploy_key | default('') | basename), omit) }}"
   register: drupal_deploy_repo_updated
   notify: clear opcache
   become: no


### PR DESCRIPTION
# Problem: 

Deploying an existing project with Git assumes that the repo is accessible to the user / machine that's doing the deploy.

For private repos, that requires additional setup before calling the role...

# Suggested fix:

This PR adds variables and parameters to copy a specified SSH key to the target node and
use that key for the Git task.