### PR TITLE
Issue #43: Fix site installed check always returning false on translated sites

### DIFF
--- a/tasks/install-site.yml
+++ b/tasks/install-site.yml
@@ -11,7 +11,7 @@
 # See: https://www.drupal.org/node/2569365#comment-11680807
 - name: Configure database correctly if using PostgreSQL.
   command: psql -c "ALTER DATABASE {{ drupal_db_name }} SET bytea_output = 'escape';"
-  when: "('Successful' not in drupal_site_installed.stdout) and (drupal_db_backend == 'pgsql')"
+  when: "('Drupal bootstrap' not in drupal_site_installed.stdout) and (drupal_db_backend == 'pgsql')"
   become: yes
   become_user: "{{ postgresql_user }}"
   # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509
@@ -30,7 +30,7 @@
   args:
     chdir: "{{ drupal_core_path }}"
   notify: clear opcache
-  when: "'Successful' not in drupal_site_installed.stdout"
+  when: "'Drupal bootstrap' not in drupal_site_installed.stdout"
   become: no
 
 - name: Install configured modules with drush.
@@ -39,5 +39,5 @@
     --root={{ drupal_core_path }}
   args:
     chdir: "{{ drupal_core_path }}"
-  when: ('Successful' not in drupal_site_installed.stdout) and drupal_enable_modules
+  when: ('Drupal bootstrap' not in drupal_site_installed.stdout) and drupal_enable_modules
   become: no


### PR DESCRIPTION
Like @azurams pointed out in https://github.com/geerlingguy/drupal-vm/issues/1399#issuecomment-305526777 the output of `drush status bootstrap` will always be empty if not installed.

> Looking at https://github.com/drush-ops/drush/blob/8.1.11/commands/core/core.drush.inc#L592, to update the drupal_site_installed check, we may assume that if drush status bootstrap does not return any new line then bootstrap failed. If the string "Drupal bootstrap" is present in the output, then bootstrap succeeded ?

The code he references shows this and drush silently gives empty output for anything which doesn't have an entry in that status-table map. eg `drush status foobar`