### PR TITLE
Install without interactions

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -26,7 +26,7 @@
 
 - name: Run composer install if composer.json is present.
   composer:
-    command: install
+    command: install -n
     working_dir: "{{ drupal_deploy_dir }}"
   when:
     - drupal_deploy_composer_file.stat.exists == true


### PR DESCRIPTION
Referred to http://docs.ansible.com/ansible/latest/composer_module.html, didn't see an "option" key for specifying `-n`.

Had this failure due to a project being patched

```
TASK [geerlingguy.drupal : Run composer install if composer.json is present.] ***
fatal: [162.243.207.46]: FAILED! => {"changed": false, "failed": true, "msg": "> DrupalProject\\composer\\ScriptHandler::checkComposerVersion Loading composer repositories with package information Installing dependencies from lock file Package operations: 0 installs, 18 updates, 0 removals - Updating composer/installers (v1.3.0 => v1.4.0): Loading from cache - Updating braintree/braintree_php (3.23.1 => 3.24.0): Loading from cache - Updating symfony/polyfill-php55 (v1.4.0 => v1.5.0): Loading from cache - Updating symfony/polyfill-php54 (v1.4.0 => v1.5.0): Loading from cache - Updating symfony/polyfill-mbstring (v1.4.0 => v1.5.0): Loading from cache - Updating webflo/drupal-finder (0.3.0 => 1.0.0): Loading from cache - Updating drupal/console-en (1.0.0 => 1.0.1): Loading from cache - Updating drupal/console-core (1.0.0 => 1.0.1): Loading from cache - Updating drupal/console (1.0.0 => 1.0.1): Loading from cache - Updating zendframework/zend-diactoros (1.4.0 => 1.4.1): Loading from cache - Updating symfony/polyfill-iconv (v1.4.0 => v1.5.0): Loading from cache - Updating symfony/polyfill-apcu (v1.4.0 => v1.5.0): Loading from cache - Updating drupal/core (8.3.6 => 8.3.7): Loading from cache - Updating square/connect (2.2.0 => 2.2.1): Loading from cache - Updating drupal/commerce_shipping dev-2.x (f6473c0 => c027f06): Checking out c027f06392 - Updating drupal/commerce_migrate dev-2.x (43cc452 => 834504e): Checking out 834504e29c - Updating drupal/commerce dev-2.x (a2fd62f => 0fde2ee): Checking out 0fde2eeb5b - Updating drupal/commerce_square dev-1.x (ecca214 => 02521c3): [RuntimeException] Source directory web/modules/contrib/commerce_square has uncommitted changes. install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [--no-suggest] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--ignore-platform-reqs] [--] [<packages>]...", "stdout": "> DrupalProject\\composer\\ScriptHandler::checkComposerVersion\nLoading composer repositories with package information\nInstalling dependencies from lock file\nPackage operations: 0 installs, 18 updates, 0 removals\n  - Updating composer/installers (v1.3.0 => v1.4.0): Loading from cache\n  - Updating braintree/braintree_php (3.23.1 => 3.24.0): Loading from cache\n  - Updating symfony/polyfill-php55 (v1.4.0 => v1.5.0): Loading from cache\n  - Updating symfony/polyfill-php54 (v1.4.0 => v1.5.0): Loading from cache\n  - Updating symfony/polyfill-mbstring (v1.4.0 => v1.5.0): Loading from cache\n  - Updating webflo/drupal-finder (0.3.0 => 1.0.0): Loading from cache\n  - Updating drupal/console-en (1.0.0 => 1.0.1): Loading from cache\n  - Updating drupal/console-core (1.0.0 => 1.0.1): Loading from cache\n  - Updating drupal/console (1.0.0 => 1.0.1): Loading from cache\n  - Updating zendframework/zend-diactoros (1.4.0 => 1.4.1): Loading from cache\n  - Updating symfony/polyfill-iconv (v1.4.0 => v1.5.0): Loading from cache\n  - Updating symfony/polyfill-apcu (v1.4.0 => v1.5.0): Loading from cache\n  - Updating drupal/core (8.3.6 => 8.3.7): Loading from cache\n  - Updating square/connect (2.2.0 => 2.2.1): Loading from cache\n  - Updating drupal/commerce_shipping dev-2.x (f6473c0 => c027f06):  Checking out c027f06392\n  - Updating drupal/commerce_migrate dev-2.x (43cc452 => 834504e):  Checking out 834504e29c\n  - Updating drupal/commerce dev-2.x (a2fd62f => 0fde2ee):  Checking out 0fde2eeb5b\n  - Updating drupal/commerce_square dev-1.x (ecca214 => 02521c3): \n                                                                                 \n  [RuntimeException]                                                             \n  Source directory web/modules/contrib/commerce_square has uncommitted changes.  \n                                                                                 \n\ninstall [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [--no-suggest] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--ignore-platform-reqs] [--] [<packages>]...\n\n", "stdout_lines": ["> DrupalProject\\composer\\ScriptHandler::checkComposerVersion", "Loading composer repositories with package information", "Installing dependencies from lock file", "Package operations: 0 installs, 18 updates, 0 removals", "  - Updating composer/installers (v1.3.0 => v1.4.0): Loading from cache", "  - Updating braintree/braintree_php (3.23.1 => 3.24.0): Loading from cache", "  - Updating symfony/polyfill-php55 (v1.4.0 => v1.5.0): Loading from cache", "  - Updating symfony/polyfill-php54 (v1.4.0 => v1.5.0): Loading from cache", "  - Updating symfony/polyfill-mbstring (v1.4.0 => v1.5.0): Loading from cache", "  - Updating webflo/drupal-finder (0.3.0 => 1.0.0): Loading from cache", "  - Updating drupal/console-en (1.0.0 => 1.0.1): Loading from cache", "  - Updating drupal/console-core (1.0.0 => 1.0.1): Loading from cache", "  - Updating drupal/console (1.0.0 => 1.0.1): Loading from cache", "  - Updating zendframework/zend-diactoros (1.4.0 => 1.4.1): Loading from cache", "  - Updating symfony/polyfill-iconv (v1.4.0 => v1.5.0): Loading from cache", "  - Updating symfony/polyfill-apcu (v1.4.0 => v1.5.0): Loading from cache", "  - Updating drupal/core (8.3.6 => 8.3.7): Loading from cache", "  - Updating square/connect (2.2.0 => 2.2.1): Loading from cache", "  - Updating drupal/commerce_shipping dev-2.x (f6473c0 => c027f06):  Checking out c027f06392", "  - Updating drupal/commerce_migrate dev-2.x (43cc452 => 834504e):  Checking out 834504e29c", "  - Updating drupal/commerce dev-2.x (a2fd62f => 0fde2ee):  Checking out 0fde2eeb5b", "  - Updating drupal/commerce_square dev-1.x (ecca214 => 02521c3): ", "                                                                                 ", "  [RuntimeException]                                                             ", "  Source directory web/modules/contrib/commerce_square has uncommitted changes.  ", "                                                                                 ", "", "install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [--no-suggest] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--ignore-platform-reqs] [--] [<packages>]...", ""]}
```