### PR TITLE
NOMERGE: Build the makefile where it exists instead of copying it anywhere

### DIFF
--- a/tasks/build-makefile.yml
+++ b/tasks/build-makefile.yml
@@ -1,10 +1,4 @@
 ---
-- name: Copy drush makefile into place.
-  copy:
-    src: "{{ drush_makefile_path }}"
-    dest: /tmp/drupal.make.yml
-  when: not drupal_site_exists
-
 - name: Ensure drupal_core_path directory exists.
   file:
     path: "{{ drupal_core_path }}"
@@ -16,7 +10,7 @@
 
 - name: Generate Drupal site with drush makefile.
   command: >
-    {{ drush_path }} make -y /tmp/drupal.make.yml {{ drush_make_options }}
+    {{ drush_path }} make -y {{ drush_makefile_path }} {{ drush_make_options }}
     chdir={{ drupal_core_path }}
   when: not drupal_site_exists
   become: no


### PR DESCRIPTION
This is meant as a reference for #55 but shouldn't actually be merged as-is. See discussion in that issue.