### PR TITLE
Wrap {{ drupal_account_pass }} in quotation marks to support passphrases

### DIFF
--- a/tasks/install-site.yml
+++ b/tasks/install-site.yml
@@ -24,7 +24,7 @@
     --root={{ drupal_core_path }}
     --site-name="{{ drupal_site_name }}"
     --account-name={{ drupal_account_name }}
-    --account-pass={{ drupal_account_pass }}
+    --account-pass="{{ drupal_account_pass }}"
     --db-url={{ drupal_db_backend }}://{{ drupal_db_user }}:{{ drupal_db_password }}@{{ drupal_db_host }}/{{ drupal_db_name }}
     {{ drupal_site_install_extra_args | join(" ") }}
   args:


### PR DESCRIPTION
It's fairly self-explanatory. Passphrases contain spaces, so this small change accommodates this. :-)