### PR TITLE
Change "falset" to "not"

### DIFF
--- a/tasks/build-composer.yml
+++ b/tasks/build-composer.yml
@@ -25,7 +25,7 @@
   composer:
     command: install
     working_dir: "{{ drupal_composer_install_dir }}"
-  when: falset drupal_site_exists
+  when: not drupal_site_exists
   become: false
 
 - name: Install dependencies with composer require (this may take a while).


### PR DESCRIPTION
This "falset" seems to be causing an Ansible template error during provisioning:

```
FAILED! => {"msg": "The conditional check 'falset drupal_site_exists' failed. The error was: template error while templating string: expected token 'end of statement block', got 'drupal_site_exists'. String: {% if falset drupal_site_exists %} True {% else %} False {% endif %}
```

Should it be "not" instead? This change allows provisioning to complete, for me.