### PR TITLE
Issue #65: Allow drupal_account_name with spaces

### DIFF
--- a/tasks/install-site.yml
+++ b/tasks/install-site.yml
@@ -23,7 +23,7 @@
     {{ drush_path }} site-install {{ drupal_install_profile | default('standard') }} -y
     --root={{ drupal_core_path }}
     --site-name="{{ drupal_site_name }}"
-    --account-name={{ drupal_account_name }}
+    --account-name="{{ drupal_account_name }}"
     --account-pass={{ drupal_account_pass }}
     --db-url={{ drupal_db_backend }}://{{ drupal_db_user }}:{{ drupal_db_password }}@{{ drupal_db_host }}/{{ drupal_db_name }}
     {{ drupal_site_install_extra_args | join(" ") }}


### PR DESCRIPTION
Wrapping {{ drupal_account_name }} in quotes allows drupal_account_name to include spaces, which is useful when you want to set a person's name as the admin username.