### PR TITLE
Offer separate_git_dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ drupal_deploy_repo: ""
 drupal_deploy_version: master
 drupal_deploy_update: true
 drupal_deploy_dir: "/var/www/drupal"
+drupal_deploy_gitdir: "/var/www/drupal.git"
 drupal_deploy_accept_hostkey: false
 drupal_deploy_composer_install: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ drupal_deploy: false
 drupal_deploy_repo: ""
 drupal_deploy_version: master
 drupal_deploy_update: true
+drupal_deploy_depth: 1
 drupal_deploy_dir: "/var/www/drupal"
 drupal_deploy_gitdir: "/var/www/drupal.git"
 drupal_deploy_accept_hostkey: false

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -14,6 +14,7 @@
     version: "{{ drupal_deploy_version }}"
     update: "{{ drupal_deploy_update }}"
     force: true
+    depth: "{{ drupal_deploy_depth }}"
     dest: "{{ drupal_deploy_dir }}"
     separate_git_dir: "{{ drupal_deploy_gitdir }}"
     accept_hostkey: "{{ drupal_deploy_accept_hostkey }}"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -15,6 +15,7 @@
     update: "{{ drupal_deploy_update }}"
     force: true
     dest: "{{ drupal_deploy_dir }}"
+    separate_git_dir: "{{ drupal_deploy_gitdir }}"
     accept_hostkey: "{{ drupal_deploy_accept_hostkey }}"
   register: drupal_deploy_repo_updated
   notify: clear opcache


### PR DESCRIPTION
Offer the option of a separate git directory which safeguards earlier commits from accidentally being shared on the website.
This functionality already exists in the ansible-git module so we are just implementing that here.
Very simple 2 line change!