### PR TITLE
Add `drupal_composer_bin_dir`.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ drupal_build_makefile: false
 drush_makefile_path: "/path/to/drupal.make.yml"
 drush_make_options: "--no-gitinfofile"
 
+# Composer let's you configure the `bin-dir` under the `config` key.
+drupal_composer_bin_dir: "vendor/bin"
+
 # Set 'drupal_build_makefile' to 'false' and this to 'true' if you are using a
 # Composer-based site deployment strategy.
 drupal_build_composer: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,13 +42,13 @@
 
 # Set Drush variables.
 - name: Check if a project specific Drush binary exists.
-  stat: "path={{ drupal_composer_install_dir }}/vendor/bin/drush"
+  stat: "path={{ drupal_composer_install_dir }}/{{ drupal_composer_bin_dir }}/drush"
   register: drush_vendor_bin
   ignore_errors: true
 
 - name: Use project specific Drush if available.
   set_fact:
-    drush_path: "{{ drupal_composer_install_dir }}/vendor/bin/drush"
+    drush_path: "{{ drupal_composer_install_dir }}/{{ drupal_composer_bin_dir }}/drush"
   when: drush_vendor_bin.stat.exists
 
 # Install site if configured.


### PR DESCRIPTION
Composer let's you specify a config key with a subkey of 'bin-dir', so
some have bin paths that are not ./vendor/bin, e.g. ./bin instead.