### PR TITLE
Support composer `--no-dev` option for dev dependencies (e.g. drush).

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ drupal_build_makefile: false
 drush_makefile_path: "/path/to/drupal.make.yml"
 drush_make_options: "--no-gitinfofile"
 
+drupal_composer_no_dev: true
+
 # Set 'drupal_build_makefile' to 'false' and this to 'true' if you are using a
 # Composer-based site deployment strategy.
 drupal_build_composer: false

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -28,6 +28,7 @@
   composer:
     command: install
     working_dir: "{{ drupal_deploy_dir }}"
+    no_dev: "{{ drupal_composer_no_dev }}"
   when:
     - drupal_deploy_composer_file.stat.exists
     - drupal_deploy_composer_install


### PR DESCRIPTION
Was having issues with drush not being found for the clear opcache handler and turns out the composer install wasn't installing drush. drush was in our require-dev section and therefore not getting installed. Adding this var `drupal_composer_no_dev: true` to our meta section got it all working nicely.