### PR TITLE
Fix deployment with other drupal_core_owner

### DIFF
--- a/tasks/build-composer-project.yml
+++ b/tasks/build-composer-project.yml
@@ -30,8 +30,28 @@
   command: >
     cp -r /tmp/composer-project/. {{ drupal_composer_install_dir }}/
     creates={{ drupal_core_path }}/index.php
-  become: false
+  become: true
+  become_user: '{{ drupal_core_owner }}'
   when: not drupal_site_exists
+
+- name: Get drupal_core_owners homedir
+  # a way to get home directory of an arbitrary user
+  # https://stackoverflow.com/questions/33343215/how-to-get-an-arbitrary-remote-users-home-directory-in-ansible
+  user:
+    name: '{{ drupal_core_owner }}'
+    state: present
+  check_mode: true
+  register: drupal_core_owner_user_registered
+  failed_when: drupal_core_owner_user_registered.changed
+
+- name: ensure caching directory for composer exists and has access rights
+  file:
+    path: "{{ drupal_core_owner_user_registered.home }}/.cache"
+    state: directory
+    owner: "{{ drupal_core_owner }}"
+    group: "{{ drupal_core_owner }}"
+    mode: 0775
+  become: true
 
 - name: Install dependencies with composer require (this may take a while).
   composer:
@@ -39,7 +59,8 @@
     arguments: "{{ item }}"
     working_dir: "{{ drupal_composer_install_dir }}"
   with_items: "{{ drupal_composer_dependencies | default([]) }}"
-  become: false
+  become: true
+  become_user: '{{ drupal_core_owner }}'
   environment:
     COMPOSER_PROCESS_TIMEOUT: 1200
     COMPOSER_MEMORY_LIMIT: '-1'

--- a/tasks/install-site.yml
+++ b/tasks/install-site.yml
@@ -31,7 +31,8 @@
     chdir: "{{ drupal_core_path }}"
   notify: clear opcache
   when: "'Drupal bootstrap' not in drupal_site_installed.stdout"
-  become: false
+  become: true
+  become_user: '{{ drupal_core_owner }}'
 
 - name: Install configured modules with drush.
   command: >
@@ -40,4 +41,5 @@
   args:
     chdir: "{{ drupal_core_path }}"
   when: ('Drupal bootstrap' not in drupal_site_installed.stdout) and drupal_enable_modules
-  become: false
+  become: true
+  become_user: '{{ drupal_core_owner }}'


### PR DESCRIPTION
for enabling the possibility to rollout drupal with e.g. "www-data" I had to fix some `become_user` and become variables.
(Debian 11)